### PR TITLE
Update nethereum-smartcontrats-gettingstarted.md propose fix to broken link for StandardToken.sol

### DIFF
--- a/docs/nethereum-smartcontrats-gettingstarted.md
+++ b/docs/nethereum-smartcontrats-gettingstarted.md
@@ -30,7 +30,7 @@ In this tutorial we are going to interact with the ERC20 standard token contract
 
 ![Constructor, transfer, balance and event of ERC20](https://github.com/Nethereum/Nethereum.Workbooks/raw/master/docs/screenshots/simpleERC20.png)
 
-A full sample of the smart contract can be found [here](https://nethereum.readthedocs.io/en/latest/Nethereum.Workbooks/docs/StandardToken.sol)
+A full sample of the smart contract can be found [here](https://github.com/Nethereum/Nethereum.Workbooks/blob/master/StandardToken.sol).
 
 First of all, we need to declare our namespaces, and contract definition to interact with the smart contract. In this scenario we are only interested in the Deployment, Transfer function and BalanceOf Function of the ERC20 smart contract.
 


### PR DESCRIPTION
The link to the `StandardToken.sol` file was broken, it used to say:
https://nethereum.readthedocs.io/en/latest/Nethereum.Workbooks/docs/StandardToken.sol which gives a 404 error.

This PR updates it to:
https://github.com/Nethereum/Nethereum.Workbooks/blob/master/StandardToken.sol

Not sure if that is correct or not.